### PR TITLE
Solución #22

### DIFF
--- a/main/ui/ui.c
+++ b/main/ui/ui.c
@@ -744,9 +744,30 @@ void ui_event_BtnStats(lv_event_t * e)
 void ui_event_ImgLogoFootbar(lv_event_t * e)
 {
     lv_event_code_t event_code = lv_event_get_code(e);
-
+    static int devmode_click_count = 0;
+    static uint32_t last_click_time = 0;
+    
     if(event_code == LV_EVENT_CLICKED) {
-        _ui_screen_change(&ui_Devmode, LV_SCR_LOAD_ANIM_FADE_ON, 300, 0, &ui_Devmode_screen_init);
+        uint32_t current_time = lv_tick_get();
+        
+        // Si han pasado más de 3 segundos desde el último click, reiniciar contador
+        if(current_time - last_click_time > 3000) {
+            devmode_click_count = 0;
+        }
+        
+        devmode_click_count++;
+        last_click_time = current_time;
+        
+        // Debug: mostrar progreso de clicks (opcional, se puede remover en producción)
+        #ifdef DEBUG_DEVMODE
+        printf("DevMode click %d/5\n", devmode_click_count);
+        #endif
+        
+        if(devmode_click_count >= 5) {
+            // Acceder al modo desarrollo después de 5 clicks
+            _ui_screen_change(&ui_Devmode, LV_SCR_LOAD_ANIM_FADE_ON, 300, 0, &ui_Devmode_screen_init);
+            devmode_click_count = 0; // Reiniciar contador
+        }
     }
 }
 


### PR DESCRIPTION
#22 closed

# Fix Issue #22: Entrada a Devmode con 5 clicks

## Problema
El acceso al modo desarrollo (Devmode) se activaba con un solo click en el logo del footbar, lo cual podía causar accesos accidentales.

## Solución Implementada
Se modificó la función `ui_event_ImgLogoFootbar` en `main/ui/ui.c` para requerir **5 clicks consecutivos** en lugar de uno solo.

## Cambios Realizados

### Archivo modificado: `main/ui/ui.c`
- **Función:** `ui_event_ImgLogoFootbar`
- **Línea:** ~746

### Funcionalidades añadidas:
1. **Contador de clicks:** Variable estática que cuenta los clicks
2. **Timeout de 3 segundos:** Si pasan más de 3 segundos entre clicks, el contador se reinicia
3. **Acceso después de 5 clicks:** Solo después del quinto click se accede al Devmode
4. **Debug opcional:** Con `DEBUG_DEVMODE` se puede ver el progreso

## Código implementado:
```c
void ui_event_ImgLogoFootbar(lv_event_t * e)
{
    lv_event_code_t event_code = lv_event_get_code(e);
    static int devmode_click_count = 0;
    static uint32_t last_click_time = 0;
    
    if(event_code == LV_EVENT_CLICKED) {
        uint32_t current_time = lv_tick_get();
        
        // Si han pasado más de 3 segundos desde el último click, reiniciar contador
        if(current_time - last_click_time > 3000) {
            devmode_click_count = 0;
        }
        
        devmode_click_count++;
        last_click_time = current_time;
        
        // Debug: mostrar progreso de clicks (opcional)
        #ifdef DEBUG_DEVMODE
        printf("DevMode click %d/5\n", devmode_click_count);
        #endif
        
        if(devmode_click_count >= 5) {
            // Acceder al modo desarrollo después de 5 clicks
            _ui_screen_change(&ui_Devmode, LV_SCR_LOAD_ANIM_FADE_ON, 300, 0, &ui_Devmode_screen_init);
            devmode_click_count = 0; // Reiniciar contador
        }
    }
}
```

## Cómo usar:
1. Hacer click 5 veces rápidamente (dentro de 3 segundos entre cada click) en el logo del footbar
2. Después del quinto click se accederá al modo desarrollo
3. Si se espera más de 3 segundos entre clicks, el contador se reinicia

## Beneficios:
- ✅ Previene acceso accidental al Devmode
- ✅ Mantiene la funcionalidad intuitiva
- ✅ Timeout inteligente para evitar clicks antiguos
- ✅ Debug opcional para desarrollo

## Estado: ✅ COMPLETADO
Issue #22 resuelto exitosamente. 