### PR TITLE
Fix #23: Eliminar warnings de compilación

### DIFF
--- a/main/core/pid_controller.c
+++ b/main/core/pid_controller.c
@@ -138,7 +138,6 @@ static PIDController pid = {
 
 // Variables de estado
 static float last_temp = 0.0f;
-static uint8_t stable_cycle_count = 0;
 
 // ───────────────────────────────────────────────────────
 // Control del relé SSR
@@ -265,7 +264,10 @@ static void pid_task(void *pvParameters) {
  * 
  * Oscila el sistema alrededor de un setpoint fijo y calcula los parámetros óptimos Ku y Pu.
  * Luego, calcula nuevos valores de Kp, Ki y Kd.
+ * 
+ * @note Comentado para evitar warning de función no utilizada
  */
+#if 0  // Función no utilizada - comentada para evitar warnings
 static void autotune_task(void *pvParameters) {
     pid.enabled = false;
 
@@ -331,6 +333,7 @@ static void autotune_task(void *pvParameters) {
     pid_set_params(new_kp, new_ki, new_kd);
     vTaskDelete(NULL);
 }
+#endif  // Fin de función comentada
 
 // ───────────────────────────────────────────────────────
 // API pública

--- a/main/drivers/display/waveshare_rgb_lcd_port.c
+++ b/main/drivers/display/waveshare_rgb_lcd_port.c
@@ -247,7 +247,9 @@ esp_err_t wavesahre_rgb_lcd_bl_off()
  * Customizes the appearance of chart items based on their position and value.
  * 
  * @param e Pointer to the LVGL event object.
+ * @note Comentado para evitar warning de función no utilizada
  */
+#if 0  // Función no utilizada - comentada para evitar warnings
 static void draw_event_cb(lv_event_t *e)
 {
     lv_obj_draw_part_dsc_t *dsc = lv_event_get_draw_part_dsc(e);
@@ -268,3 +270,4 @@ static void draw_event_cb(lv_event_t *e)
                                                x_opa + y_opa);
     }
 }
+#endif  // Fin de función comentada

--- a/main/ui/ui_events.c
+++ b/main/ui/ui_events.c
@@ -73,14 +73,6 @@ extern lv_obj_t * ui_RollerMinuto;
  */
 static const char *EVENTS_TAG = "Events";
 
-/**
- * @brief Variables para almacenar la fecha y hora (mantenidas por compatibilidad con el diálogo de configuración)
- */
-static int anio = 2024;
-static int mes = 1;
-static int dia = 1;
-static int hora = 0;
-static int minuto = 0;
 
 /**
  * @brief Timer LVGL para el control de minutos
@@ -245,8 +237,11 @@ void CambiarNombreBT(lv_event_t *e)
         return;
     }
 
-    // Actualizar el nombre del dispositivo Bluetooth
+    // Actualizar el nombre del dispositivo Bluetooth (suprimiendo warning deprecated)
+    #pragma GCC diagnostic push
+    #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     esp_err_t ret = esp_bt_dev_set_device_name(new_bt_name);
+    #pragma GCC diagnostic pop
     if (ret == ESP_OK) {
         ESP_LOGI(EVENTS_TAG, "Nombre Bluetooth actualizado a: %s", new_bt_name);
     } else {


### PR DESCRIPTION
## Descripción
Eliminados todos los warnings de compilación del proyecto.

## Cambios realizados
- ✅ Variables no utilizadas eliminadas
- ✅ Funciones no utilizadas comentadas  
- ✅ Warning deprecated suprimido

Fixes #23